### PR TITLE
Renamed `remotePublisherClosure` parameters to `dataTaskPublisher`

### DIFF
--- a/Sources/Combinefall/AutocompletePublishers.swift
+++ b/Sources/Combinefall/AutocompletePublishers.swift
@@ -7,7 +7,7 @@ public typealias AutocompleteCatalog = Catalog<String>
 // Used internaly to inject remote publisher for testing.
 // swiftlint:disable:next identifier_name
 func _autocompleteCatalogPublisher<U: Publisher, R: Publisher, S: Scheduler> (
-    upstream: U, remotePublisherClosure: @escaping (URLRequest) -> R, scheduler: S
+    upstream: U, dataTaskPublisher: @escaping (URLRequest) -> R, scheduler: S
 ) -> AnyPublisher<AutocompleteCatalog, Combinefall.Error>
     where
     U.Output == String,
@@ -19,7 +19,7 @@ func _autocompleteCatalogPublisher<U: Publisher, R: Publisher, S: Scheduler> (
                 .debounce(for: .milliseconds(100), scheduler: scheduler)
                 .removeDuplicates()
                 .map { EndpointComponents.autocomplete(searchTerm: $0) },
-            remotePublisherClosure: remotePublisherClosure
+            dataTaskPublisher: dataTaskPublisher
         )
 }
 
@@ -41,7 +41,7 @@ public func autocompleteCatalogPublisher<U: Publisher, S: Scheduler>(upstream: U
     -> AnyPublisher<AutocompleteCatalog, Error> where U.Output == String, U.Failure == Never {
         _autocompleteCatalogPublisher(
             upstream: upstream,
-            remotePublisherClosure: URLSession.shared.dataTaskPublisher,
+            dataTaskPublisher: URLSession.shared.dataTaskPublisher,
             scheduler: scheduler
         )
 }
@@ -49,7 +49,7 @@ public func autocompleteCatalogPublisher<U: Publisher, S: Scheduler>(upstream: U
 // Used internaly to inject remote publisher for testing.
 // swiftlint:disable:next identifier_name
 func _autocompletePublisher<U: Publisher, R: Publisher, S: Scheduler>(
-    upstream: U, remotePublisherClosure: @escaping (URLRequest) -> R, scheduler: S
+    upstream: U, dataTaskPublisher: @escaping (URLRequest) -> R, scheduler: S
 ) -> AnyPublisher<[String], Error>
     where
     U.Output == String,
@@ -58,7 +58,7 @@ func _autocompletePublisher<U: Publisher, R: Publisher, S: Scheduler>(
     R.Failure == URLSession.DataTaskPublisher.Failure {
         _autocompleteCatalogPublisher(
             upstream: upstream,
-            remotePublisherClosure: remotePublisherClosure,
+            dataTaskPublisher: dataTaskPublisher,
             scheduler: scheduler
         )
             .map { $0.data }
@@ -83,7 +83,7 @@ public func autocompletePublisher<U: Publisher, S: Scheduler>(upstream: U, sched
     -> AnyPublisher<[String], Error> where U.Output == String, U.Failure == Never {
         _autocompletePublisher(
             upstream: upstream,
-            remotePublisherClosure: URLSession.shared.dataTaskPublisher,
+            dataTaskPublisher: URLSession.shared.dataTaskPublisher,
             scheduler: scheduler
         )
 }

--- a/Sources/Combinefall/Card.swift
+++ b/Sources/Combinefall/Card.swift
@@ -394,25 +394,25 @@ public struct Card: ScryfallModel {
 
     // Used internaly to inject remote publisher for testing.
     // swiftlint:disable:next identifier_name
-    func _alternativePrintsListPublisher<R: Publisher>(remotePublisherClosure: @escaping (URLRequest) -> R)
+    func _alternativePrintsListPublisher<R: Publisher>(dataTaskPublisher: @escaping (URLRequest) -> R)
         -> AnyPublisher<CardList, Error>
     where R.Output == URLSession.DataTaskPublisher.Output, R.Failure == URLSession.DataTaskPublisher.Failure {
-        fetchPublisher(upstream: Just(URLRequest(url: printsSearchUrl)), remotePublisherClosure: remotePublisherClosure)
+        fetchPublisher(upstream: Just(URLRequest(url: printsSearchUrl)), R: dataTaskPublisher)
     }
 
     /// Creates a publisher that will publish all of the alternativ prints of this card.
     ///
     /// - Returns: A publisher that publishes a `CardCatalog` with all alternative prints of this `Card`.
     public func alternativePrintsListPublisher<S: Scheduler>(on scheduler: S) -> AnyPublisher<CardList, Error> {
-        _alternativePrintsListPublisher(remotePublisherClosure: URLSession.shared.dataTaskPublisher)
+        _alternativePrintsListPublisher(dataTaskPublisher: URLSession.shared.dataTaskPublisher)
     }
 
     // Used internaly to inject remote publisher for testing.
     // swiftlint:disable:next identifier_name
-    public func _alternativePrintsPublisher<R: Publisher>(remotePublisherClosure: @escaping (URLRequest) -> R)
+    public func _alternativePrintsPublisher<R: Publisher>(dataTaskPublisher: @escaping (URLRequest) -> R)
         -> AnyPublisher<[Card], Error>
     where R.Output == URLSession.DataTaskPublisher.Output, R.Failure == URLSession.DataTaskPublisher.Failure {
-        _alternativePrintsListPublisher(remotePublisherClosure: remotePublisherClosure)
+        _alternativePrintsListPublisher(dataTaskPublisher: dataTaskPublisher)
             .map { $0.data }
             .eraseToAnyPublisher()
     }
@@ -421,7 +421,7 @@ public struct Card: ScryfallModel {
     ///
     /// - Returns: A publisher that publishes a `[Card]` with all alternative prints of this `Card`.
     public func alternativePrintsPublisher() -> AnyPublisher<[Card], Error> {
-        _alternativePrintsPublisher(remotePublisherClosure: URLSession.shared.dataTaskPublisher)
+        _alternativePrintsPublisher(dataTaskPublisher: URLSession.shared.dataTaskPublisher)
     }
 
     // MARK: - Decodeable

--- a/Sources/Combinefall/Card.swift
+++ b/Sources/Combinefall/Card.swift
@@ -397,7 +397,7 @@ public struct Card: ScryfallModel {
     func _alternativePrintsListPublisher<R: Publisher>(dataTaskPublisher: @escaping (URLRequest) -> R)
         -> AnyPublisher<CardList, Error>
     where R.Output == URLSession.DataTaskPublisher.Output, R.Failure == URLSession.DataTaskPublisher.Failure {
-        fetchPublisher(upstream: Just(URLRequest(url: printsSearchUrl)), R: dataTaskPublisher)
+        fetchPublisher(upstream: Just(URLRequest(url: printsSearchUrl)), dataTaskPublisher: dataTaskPublisher)
     }
 
     /// Creates a publisher that will publish all of the alternativ prints of this card.

--- a/Sources/Combinefall/CardCollectionPublishers.swift
+++ b/Sources/Combinefall/CardCollectionPublishers.swift
@@ -59,7 +59,7 @@ public struct CardIdentifiers: Encodable {
 
 // swiftlint:disable:next identifier_name
 func _cardCollectionPublisher<U: Publisher, R: Publisher>(
-    upstream: U, remotePublisherClosure: @escaping (URLRequest) -> R
+    upstream: U, dataTaskPublisher: @escaping (URLRequest) -> R
 ) -> AnyPublisher<CardList, Error>
     where
     U.Output == CardIdentifiers,
@@ -68,7 +68,7 @@ func _cardCollectionPublisher<U: Publisher, R: Publisher>(
     R.Failure == URLSession.DataTaskPublisher.Failure {
         fetchPublisher(
             upstream: upstream.map { EndpointComponents.cardCollection($0) },
-            remotePublisherClosure: remotePublisherClosure
+            dataTaskPublisher: dataTaskPublisher
         )
 }
 
@@ -83,7 +83,7 @@ func _cardCollectionPublisher<U: Publisher, R: Publisher>(
 /// - Returns: A publisher that publishes `CardList` mathing the given `upstream` published element.
 public func cardCollectionPublisher<U: Publisher>(upstream: U) -> AnyPublisher<CardList, Error>
     where U.Output == CardIdentifiers, U.Failure == Never {
-        return _cardCollectionPublisher(upstream: upstream, remotePublisherClosure: URLSession.shared.dataTaskPublisher)
+        return _cardCollectionPublisher(upstream: upstream, dataTaskPublisher: URLSession.shared.dataTaskPublisher)
 }
 
 public extension Publisher where Self.Output == CardIdentifiers, Self.Failure == Never {

--- a/Sources/Combinefall/CardImagePublishers.swift
+++ b/Sources/Combinefall/CardImagePublishers.swift
@@ -16,9 +16,8 @@ public struct CardImageParameters {
 }
 
 // swiftlint:disable:next identifier_name
-func _cardImageDataPublisher<U: Publisher, R: Publisher>(
-    upstream: U, remotePublisherClosure: @escaping (URLRequest) -> R
-) -> AnyPublisher<Data, Error>
+func _cardImageDataPublisher<U: Publisher, R: Publisher>(upstream: U, dataTaskPublisher: @escaping (URLRequest) -> R)
+    -> AnyPublisher<Data, Error>
     where
     U.Output == CardImageParameters,
     U.Failure == Never,
@@ -26,7 +25,7 @@ func _cardImageDataPublisher<U: Publisher, R: Publisher>(
     R.Failure == URLSession.DataTaskPublisher.Failure {
         dataPublisher(
             upstream: upstream.map { EndpointComponents.cardImage(named: $0.name, version: $0.version).urlRequest },
-            remotePublisherClosure: remotePublisherClosure
+            dataTaskPublisher: dataTaskPublisher
         )
             .eraseToAnyPublisher()
 }
@@ -41,7 +40,7 @@ func _cardImageDataPublisher<U: Publisher, R: Publisher>(
 /// - Returns: A publisher that publishes `Data` mathing the given `upstream` published element.
 public func cardImageDataPublisher<U: Publisher>(upstream: U) -> AnyPublisher<Data, Error>
     where U.Output == CardImageParameters, U.Failure == Never {
-        _cardImageDataPublisher(upstream: upstream, remotePublisherClosure: URLSession.shared.dataTaskPublisher)
+        _cardImageDataPublisher(upstream: upstream, dataTaskPublisher: URLSession.shared.dataTaskPublisher)
 }
 
 public extension Publisher where Self.Output == CardImageParameters, Self.Failure == Never {

--- a/Sources/Combinefall/CardPublishers.swift
+++ b/Sources/Combinefall/CardPublishers.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // Used internaly to inject remote publisher for testing.
 // swiftlint:disable:next identifier_name
-func _cardPublisher<U: Publisher, R: Publisher> (upstream: U, remotePublisherClosure: @escaping (URLRequest) -> R)
+func _cardPublisher<U: Publisher, R: Publisher> (upstream: U, dataTaskPublisher: @escaping (URLRequest) -> R)
     -> AnyPublisher<Card, Combinefall.Error>
     where
     U.Output == String,
@@ -12,7 +12,7 @@ func _cardPublisher<U: Publisher, R: Publisher> (upstream: U, remotePublisherClo
     R.Failure == URLSession.DataTaskPublisher.Failure {
         fetchPublisher(
             upstream: upstream.map { EndpointComponents.card(named: $0) },
-            remotePublisherClosure: remotePublisherClosure
+            dataTaskPublisher: dataTaskPublisher
         )
 }
 
@@ -27,7 +27,7 @@ public func cardPublisher<U: Publisher>(upstream: U) -> AnyPublisher<Card, Error
     where U.Output == String, U.Failure == Never {
         _cardPublisher(
             upstream: upstream,
-            remotePublisherClosure: URLSession.shared.dataTaskPublisher
+            dataTaskPublisher: URLSession.shared.dataTaskPublisher
         )
 }
 

--- a/Sources/Combinefall/List.swift
+++ b/Sources/Combinefall/List.swift
@@ -27,17 +27,16 @@ public struct List<T: Decodable>: ScryfallModel {
 
     // Used internaly to inject remote publisher for testing.
     // swiftlint:disable:next identifier_name
-    func _nextPagePublisher<R: Publisher>(
-        remotePublisherClosure: @escaping (URLRequest) -> R
-    ) -> AnyPublisher<Self, Error>?
-    where R.Output == URLSession.DataTaskPublisher.Output, R.Failure == URLSession.DataTaskPublisher.Failure {
-        guard let nextPage = nextPage else { return nil }
-        return fetchPublisher(upstream: Just(URLRequest(url: nextPage)), remotePublisherClosure: remotePublisherClosure)
+    func _nextPagePublisher<R: Publisher>(dataTaskPublisher: @escaping (URLRequest) -> R)
+        -> AnyPublisher<Self, Error>?
+        where R.Output == URLSession.DataTaskPublisher.Output, R.Failure == URLSession.DataTaskPublisher.Failure {
+            guard let nextPage = nextPage else { return nil }
+            return fetchPublisher(upstream: Just(URLRequest(url: nextPage)), dataTaskPublisher: dataTaskPublisher)
     }
 
     /// Creates a publisher that publises the next page of this `List`.
     public func nextPagePublisher() -> AnyPublisher<Self, Error>? {
-        _nextPagePublisher(remotePublisherClosure: URLSession.shared.dataTaskPublisher)
+        _nextPagePublisher(dataTaskPublisher: URLSession.shared.dataTaskPublisher)
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Tests/CombinefallTests/Card/PublishersTests.swift
+++ b/Tests/CombinefallTests/Card/PublishersTests.swift
@@ -10,7 +10,7 @@ final class PublishersTests: XCTestCase {
     func testAlternativePrintsListPublisher() {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = testCard._alternativePrintsListPublisher(
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
             )
             .assertNoFailure()
             .sink { _ in expectation.fulfill() }
@@ -20,7 +20,7 @@ final class PublishersTests: XCTestCase {
     func testAlternativePrintsPublisher() {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = testCard._alternativePrintsPublisher(
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
             )
             .assertNoFailure()
             .sink { _ in expectation.fulfill() }

--- a/Tests/CombinefallTests/ListTests.swift
+++ b/Tests/CombinefallTests/ListTests.swift
@@ -36,7 +36,7 @@ final class ListTests: XCTestCase {
         let testList = try! JSONDecoder().decode(List<Card>.self, from: TestData.cardListWithMore.data)
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = testList._nextPagePublisher(
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
             )?
             .assertNoFailure()
             .sink { _ in expectation.fulfill() }

--- a/Tests/CombinefallTests/Publishers/AutocompleteTests.swift
+++ b/Tests/CombinefallTests/Publishers/AutocompleteTests.swift
@@ -10,7 +10,7 @@ final class AutocompleteTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = _autocompleteCatalogPublisher(
                 upstream: $testUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) },
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) },
                 scheduler: RunLoop.current
             )
             .assertNoFailure()
@@ -27,7 +27,7 @@ final class AutocompleteTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = _autocompletePublisher(
                 upstream: $testUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) },
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) },
                 scheduler: RunLoop.current
             )
             .assertNoFailure()

--- a/Tests/CombinefallTests/Publishers/CardCollectionPublisherTests.swift
+++ b/Tests/CombinefallTests/Publishers/CardCollectionPublisherTests.swift
@@ -10,7 +10,7 @@ final class CardCollectionPublisherTests: XCTestCase {
         let valueExpectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = _cardCollectionPublisher(
                 upstream: $testUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.cardList) }
             )
         .assertNoFailure()
         .sink { _ in valueExpectation.fulfill() }

--- a/Tests/CombinefallTests/Publishers/CardImageDataPublisherTests.swift
+++ b/Tests/CombinefallTests/Publishers/CardImageDataPublisherTests.swift
@@ -10,7 +10,7 @@ final class CardImageDataPublisherTests: XCTestCase {
         let valueExpectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = _cardImageDataPublisher(
             upstream: $testUpstream,
-            remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
+            dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
         )
             .assertNoFailure()
             .sink {

--- a/Tests/CombinefallTests/Publishers/CardPublisherTests.swift
+++ b/Tests/CombinefallTests/Publishers/CardPublisherTests.swift
@@ -10,7 +10,7 @@ final class CardPublisherTests: XCTestCase {
         let valueExpectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = _cardPublisher(
             upstream: $testUpstream,
-            remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.card) }
+            dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.card) }
         )
             .assertNoFailure()
             .sink { _ in valueExpectation.fulfill() }

--- a/Tests/CombinefallTests/Publishers/DataPublisherTests.swift
+++ b/Tests/CombinefallTests/Publishers/DataPublisherTests.swift
@@ -36,7 +36,7 @@ final class DataPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = dataPublisher(
                 upstream: $testURLRequestUpstream,
-                remotePublisherClosure: { (_: URLRequest) in FailingURLSessionMockPublisher() }
+                dataTaskPublisher: { (_: URLRequest) in FailingURLSessionMockPublisher() }
             )
             .sink(
                 receiveCompletion: {
@@ -60,7 +60,7 @@ final class DataPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = dataPublisher(
                 upstream: $testURLRequestUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
             )
             .assertNoFailure()
             .sink {
@@ -74,7 +74,7 @@ final class DataPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = dataPublisher(
                 upstream: $testEndpointComponentsUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
             )
             .assertNoFailure()
             .sink {

--- a/Tests/CombinefallTests/Publishers/FetchPublisherTests.swift
+++ b/Tests/CombinefallTests/Publishers/FetchPublisherTests.swift
@@ -12,7 +12,7 @@ final class FetchPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = (fetchPublisher(
                 upstream: $testURLRequestUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.invalid) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.invalid) }
             ) as AnyPublisher<AutocompleteCatalog, Combinefall.Error>)
             .sink(
                 receiveCompletion: {
@@ -29,7 +29,7 @@ final class FetchPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = (fetchPublisher(
                 upstream: $testURLRequestUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
             ) as AnyPublisher<AutocompleteCatalog, Combinefall.Error>)
             .sink(
                 receiveCompletion: { _ in },
@@ -42,7 +42,7 @@ final class FetchPublisherTests: XCTestCase {
         let expectation = XCTestExpectation(description: "Let publisher publish")
         cancellable = (fetchPublisher(
                 upstream: $testEndpointComponentsUpstream,
-                remotePublisherClosure: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
+                dataTaskPublisher: { (_: URLRequest) in URLSessionMockPublisher(testData: TestData.catalog) }
             ) as AnyPublisher<AutocompleteCatalog, Combinefall.Error>)
             .sink(
                 receiveCompletion: { _ in },


### PR DESCRIPTION
This better reflect what the parameter actually is.